### PR TITLE
testEncryptDecrypt passes

### DIFF
--- a/src/eckem.js
+++ b/src/eckem.js
@@ -18,8 +18,6 @@ async function encrypt(pt, pubA) {
   const kpE = EC.newKeyPair()
   const secret = await kpE.computeSecret(pubA)
   const cipher = EC.cbcEncrypt(pt, secret)
-  console.log('------plaintext------')
-  console.log(pt)
   return JSON.stringify({ pub: kpE.publicKey, cipher })
 }
 
@@ -35,8 +33,6 @@ async function decrypt(_cipherData, priv) {
   const { cipher, pub } = cipherData
   const secret = await EC.computeSecret(priv, pub)
   const pt = EC.decrypt(cipher, secret)
-  console.log('------decipher-------')
-  console.log(pt)
   return pt
 }
 

--- a/src/eth-crypto/ecUtil.js
+++ b/src/eth-crypto/ecUtil.js
@@ -27,7 +27,7 @@ function encryptWithPublicKey(publicKey, message, serialize = true) {
 
 function decryptWithPrivateKey(cipher, privateKey) {
   const _cipher = typeof cipher == 'string' ? parseCipher(cipher) : cipher
-  return ecDecryptWithPrivateKey(_cipher, privateKey)
+  return ecDecryptWithPrivateKey(privateKey, _cipher)
 }
 
 module.exports = {

--- a/src/tree-math.js
+++ b/src/tree-math.js
@@ -9,7 +9,7 @@ function log2(x) {
 }
 
 function level(x) {
-  if ((x & 0x01) == 0) {
+  if ((x & 0x01) == 0) { // if even
     return 0;
   }
 

--- a/src/treekem.js
+++ b/src/treekem.js
@@ -156,16 +156,12 @@ class TreeKEM {
    *   }
    */
   async encrypt(leaf, except) {
-    let dirpath = tm.dirpath(2 * except, this.size);
     let copath = tm.copath(2 * except, this.size);
 
     // Generate hashes up the tree
     let privateNodes = await TreeKEM.hashUp(2 * except, this.size, leaf);
     let nodes = {};
     for (let n in privateNodes) {
-      if (isNaN(n)) {
-        continue; // filter out NaNs because they create confusion
-      }
       nodes[n] = util.publicNode(privateNodes[n]);
     }
 
@@ -218,13 +214,13 @@ class TreeKEM {
                         .map(x => parseInt(x))
                         .filter(x => dirpath.includes(x))[0];
 
-    console.log('-------decrypt-------')
-    console.log(encryptions[decNode])
-    if (this.nodes[decNode] == null) {
-      debugger;
-    } else {
-      console.log(this.nodes[decNode].private)
-    }
+    // console.log('-------decrypt-------')
+    // console.log(encryptions[decNode])
+    // if (this.nodes[decNode] == null) {
+    //   debugger;
+    // } else {
+    //   console.log(this.nodes[decNode].private)
+    // }
     let h = await ECKEM.decrypt(encryptions[decNode], this.nodes[decNode].private);
     
     // Hash up to the root (plus one if we're growing the tree)
@@ -353,7 +349,6 @@ class TreeKEM {
       }
   
       n = tm.parent(n, size);
-      console.log(n)
       path.push(n);
       h = hash(h);
     }
@@ -392,7 +387,6 @@ async function testMembers(size) {
   let nodeWidth = tm.nodeWidth(size);
   let keyPairs = [...Array(nodeWidth).keys()].map(i => {
     const kp = iota(new Uint8Array([i]))
-    console.log(kp.publicKey)
     return kp
   })
 
@@ -451,12 +445,7 @@ async function testEncryptDecrypt() {
       if (m2.index == m.index) {
         continue;
       }
-      m.dump('m')
-      m2.dump('m2')
-
       let pt = JSON.parse(JSON.stringify(await m2.decrypt(m.index, ct.ciphertexts)))
-      console.log(pt)
-      console.log(typeof pt)
       if (!arrayBufferEqual(ct.root, pt.root)) {
         console.log("error:", m.index, "->", m2.index);
         console.log("send:", hex(ct.root));
@@ -468,9 +457,6 @@ async function testEncryptDecrypt() {
       m2.merge(ct.nodes);
       m2.merge(pt.nodes);
 
-      // TODO there requires a conversion to eth-crypto cipher format
-      // https://github.com/d1ll0n/eth-treekem/issues/4
-      // console.log(EC.decryptWithPrivateKey(JSON.parse(ct.ciphertexts[0][2]), m2.nodes[m2.index].private))
       let eq = await m.equal(m2);
       if (!eq) {
         console.log("error:", m.index, "->", m2.index);

--- a/src/treekem.js
+++ b/src/treekem.js
@@ -469,14 +469,14 @@ async function testEncryptDecrypt() {
 }
 
 async function testSimultaneousUpdate() {
-  const testGroupSize = 5;
+  const testGroupSize = 2;
   let members = await testMembers(testGroupSize);
 
   // Have each member emit an update, then have everyone compute and
   // apply a merged update
   let seeds = members.map(m => new Uint8Array([m.index]));
   let cts = await Promise.all(members.map(m => {
-    return m.encrypt(seeds[m.index]);
+    return m.encrypt(seeds[m.index], m.index);
   }));
 
   let secrets = await Promise.all(members.map(async m => {
@@ -522,8 +522,6 @@ async function testSimultaneousUpdate() {
       let eq = await m1.equal(m2);
       if (!eq) {
         console.log("error:", m1.index, "!=", m2.index);
-        await m1.dump();
-        await m2.dump();
         throw 'tkem-simultaneous-tree';
       }
     }


### PR DESCRIPTION
The new public key for the sending node was not being updated on message send,
resulting in trees that were not in sync. After updateing the encrypt function
to pass in the sender index when encrypting, the dirpath and copath would be
calculated properly resulting in the proper public keys nodes to be generated in
the state update.

NOTE: testSimultaneousUpdate still fails when trying to decrypt. It looks like it is unable to find the proper value to encrypt, which could because of an ordering issue with tree state updates. Still needs investigation